### PR TITLE
Add reminder for DOCPR value map

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -49,7 +49,7 @@ jobs:
 
                 if if [ $(($WEEK_DAY_NUM)) -eq 4 ];  # every Thursday
                 then
-                  msg="Friendly reminder to add your DOCPR efforts to the [value map](https://docs.google.com/spreadsheets/d/1QuPgSSicRj8rW_Q05gzKSl6KcYoM8M5RSVvHMnfuw7Q/edit?usp=sharing) :) \n See ["How to use the value map"](https://library.canonical.com/our-organisation/engineering-excellence/documentation/handbook-for-technical-authors/guides-and-explanation/use-value-map) for more information. \n Reach out to the value map gatekeeper (Erin) with any questions!"
+                  msg="Friendly reminder to add your DOCPR efforts to the [value map](https://docs.google.com/spreadsheets/d/1QuPgSSicRj8rW_Q05gzKSl6KcYoM8M5RSVvHMnfuw7Q/edit?usp=sharing) :)\n See [How to use the value map](https://library.canonical.com/our-organisation/engineering-excellence/documentation/handbook-for-technical-authors/guides-and-explanation/use-value-map) for more information. Reach out to the value map gatekeeper (Erin) with any questions!"
                   send_mattermost_msg "$msg"
                 fi
 #Enable workflow run

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -30,4 +30,26 @@ jobs:
                     send_mattermost_msg "$msg"
                   fi
                 fi
+    send-docpr-value-map-reminder:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Send DOCPR value map reminders for technical authors
+              env:
+                WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+              run: |
+                WEEK_DAY_NUM=`date +"%u"`
+
+                function send_mattermost_msg() {
+                  msg="$1"
+                  curl -i -X POST \
+                    -H 'Content-Type:application/json' \
+                    -d "{\"text\": \"$msg\"}" \
+                    "$WEBHOOK_URL"
+                }
+
+                if if [ $(($WEEK_DAY_NUM)) -eq 4 ];  # every Thursday
+                then
+                  msg="Friendly reminder to add your DOCPR efforts to the [value map](https://docs.google.com/spreadsheets/d/1QuPgSSicRj8rW_Q05gzKSl6KcYoM8M5RSVvHMnfuw7Q/edit?usp=sharing) :) \n See ["How to use the value map"](https://library.canonical.com/our-organisation/engineering-excellence/documentation/handbook-for-technical-authors/guides-and-explanation/use-value-map) for more information. \n Reach out to the value map gatekeeper (Erin) with any questions!"
+                  send_mattermost_msg "$msg"
+                fi
 #Enable workflow run


### PR DESCRIPTION
Add a scheduled (bot) reminder about the value map so that the TAs are notified on a consistent basis to add their DOCPR work and know where to find more information. This reduces the mental load of the gatekeeper to remind TAs.